### PR TITLE
feat: support Basic Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
     --username Login username
     --password User's password
     --proxy Proxy server
+    --basic-auth-username username for Basic Authentication
+    --basic-auth-password password for Basic Authentication
     --watch Watch the changes of plugin zip and re-run
     --lang Using language (en or ja)
 
@@ -58,6 +60,8 @@ You can create a project based on `@kintone/plugin-packer` using [@kintone/creat
     domain: KINTONE_DOMAIN
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
+    basic-auth-username: KINTONE_BASIC_AUTH_USERNAME
+    basic-auth-password: KINTONE_BASIC_AUTH_PASSWORD
     proxy: HTTPS_PROXY or HTTP_PROXY
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,7 +14,9 @@ const {
   HTTPS_PROXY,
   KINTONE_DOMAIN,
   KINTONE_USERNAME,
-  KINTONE_PASSWORD
+  KINTONE_PASSWORD,
+  KINTONE_BASIC_AUTH_USERNAME,
+  KINTONE_BASIC_AUTH_PASSWORD
 } = process.env;
 
 const cli = meow(
@@ -26,6 +28,8 @@ const cli = meow(
     --username Login username
     --password User's password
     --proxy Proxy server
+    --basic-auth-username username for Basic Authentication
+    --basic-auth-password password for Basic Authentication
     --watch Watch the changes of plugin zip and re-run
     --waiting-dialog-ms A ms for waiting show a input dialog
     --lang Using language (en or ja)
@@ -34,6 +38,8 @@ const cli = meow(
     domain: KINTONE_DOMAIN
     username: KINTONE_USERNAME
     password: KINTONE_PASSWORD
+    basic-auth-username: KINTONE_BASIC_AUTH_USERNAME
+    basic-auth-password: KINTONE_BASIC_AUTH_PASSWORD
     proxy: HTTPS_PROXY or HTTP_PROXY
 `,
   {
@@ -53,6 +59,14 @@ const cli = meow(
       proxy: {
         type: "string",
         default: HTTPS_PROXY || HTTP_PROXY || ''
+      },
+      basicAuthUsername: {
+        type: "string",
+        default: KINTONE_BASIC_AUTH_USERNAME || ''
+      },
+      basicAuthPassword: {
+        type: "string",
+        default: KINTONE_BASIC_AUTH_PASSWORD || ''
       },
       watch: {
         type: "boolean",
@@ -76,11 +90,18 @@ const {
   password,
   domain,
   proxy,
+  basicAuthUsername,
+  basicAuthPassword,
   watch,
   waitingDialogMs,
   lang
 } = cli.flags;
-const options = proxy ? { watch, lang, proxyServer: proxy } : { watch, lang };
+
+const basicAuth = basicAuthUsername !== "" && basicAuthPassword !== "" ? {
+  username: basicAuthUsername,
+  password: basicAuthPassword
+} : null;
+const options = { watch, lang, proxyServer: proxy !== "" ? proxy : null, basicAuth };
 
 if (!pluginPath) {
   console.error(getMessage(lang, "Error_requiredZipPath"));


### PR DESCRIPTION
Fixes #298 

This adds new options to support Basic Authentication.
You can enable Basic Authentication by the following ways

- CLI flags

```
% kintone-plugin-uploader plugin.zip  --basic-auth-username foo --basic-auth-password bar
```

- Environment variables

```
% export KINTONE_BASIC_AUTH_USERNAME=foo
% export KINTONE_BASIC_AUTH_USERNAME=bar
% kintone-plugin-uploader plugin.zip  --basic-auth-username foo
```
