### PR TITLE
fix: ease timeout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { Lang } from "./lang";
 import { getBoundMessage } from "./messages";
 
 const TIMEOUT_MS = 5000;
+const UPLOAD_TIMEOUT_MS = 60000;
 
 interface BasicAuth {
   username: string;
@@ -88,7 +89,7 @@ async function upload(
   await page.click('button[name="ok"]');
   await page.waitForSelector(".ocean-ui-dialog", {
     hidden: true,
-    timeout: TIMEOUT_MS,
+    timeout: UPLOAD_TIMEOUT_MS,
   });
   console.log(`${pluginPath} ${m("Uploaded")}`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import puppeteer, { Browser, Page } from "puppeteer";
 import { Lang } from "./lang";
 import { getBoundMessage } from "./messages";
 
-const TIMEOUT_MS = 5000;
+const TIMEOUT_MS = 10000;
 const UPLOAD_TIMEOUT_MS = 60000;
 
 interface BasicAuth {


### PR DESCRIPTION
<!-- Thank you for sending a pull request! -->

## Why

<!-- Why do you want the feature and why does it make sense for the package? -->

Sometimes `plugin-uploader` is occurred a timeout error for uploading a large plugin file.
I want to ease some timeout settings for puppeteer.

fixes: https://github.com/kintone/plugin-uploader/issues/82 and https://github.com/kintone/plugin-uploader/issues/211 

## What

<!-- What is a solution you want to add? -->
change timeout for puppeteer as follows:
- wait for hiding upload dialog: 5,000ms -> 60,000ms
- wait for other operations: 5,000ms -> 10,000ms

## How to test

<!-- How can we test this pull request? -->
- `npm run lint`
- `npm run build` && `node bin/cli.js plugin.zip`